### PR TITLE
Renames all references to GB to Subvisual

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 Group Buddies
+Copyright (c) 2014-2015 GB-Software As A Service, Lda
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GB Puppet
+# Subvisual Puppet
 
 A Puppet module and a few helper scripts to set up web servers
 
@@ -14,7 +14,7 @@ For the default base setup for a web server, the `ubuntu` helper script can be
 applied. To use it, SSH into a newly created machine, and run this command:
 
 ```bash
-curl -s https://raw.githubusercontent.com/groupbuddies/gb-puppet/master/setup/ubuntu > install
+curl -s https://raw.githubusercontent.com/subvisual/subvisual-puppet/master/setup/ubuntu > install
 chmod +x install
 ./install
 ```
@@ -23,8 +23,8 @@ This will:
 
 * install some base packages (git, puppet)
 * create a `deploy` user. You will be prompted for a password at the end
-* Add all of [GB's public keys](https://github.com/groupbuddies/public-keys) to the `deploy` user
-* Adds [GB's dotfiles](https://github.com/groupbuddies/dotfiles) to the `deploy` user using [rcm](https://github.com/thoughtbot/rcm)
+* Add all of [Subvisual public keys](https://github.com/subvisual/public-keys) to the `deploy` user
+* Adds [Subvisual dotfiles](https://github.com/subvisual/dotfiles) to the `deploy` user using [rcm](https://github.com/thoughtbot/rcm)
 * ensure `/apps` (where all web apps will go) belongs to the `deploy` user
 * enable Upstart session jobs
 * install nginx
@@ -62,7 +62,7 @@ common:
 The `setup/app` helper script  assists with getting these files on the server and provisioning it. No SSH needed at this stage:
 
 ```bash
-curl -s https://raw.githubusercontent.com/groupbuddies/gb-puppet/master/setup/app > install-app
+curl -s https://raw.githubusercontent.com/subvisual/subvisual-puppet/master/setup/app > install-app
 chmod +x install-app
 ./install-app
 ```

--- a/puppet-module/files/dotfiles.sh
+++ b/puppet-module/files/dotfiles.sh
@@ -8,7 +8,7 @@ RCRC="$HOME/.rcrc"
 if [ -d $REPO ]; then
   cd $REPO && git pull
 else
-  git clone https://github.com/groupbuddies/dotfiles $HOME/.dotfiles
+  git clone https://github.com/subvisual/dotfiles $HOME/.dotfiles
 fi
 
 cd $HOME && rcup -d $REPO -x README.md -x LICENSE -x Brewfile -x samples

--- a/puppet-module/manifests/public_keys.pp
+++ b/puppet-module/manifests/public_keys.pp
@@ -3,7 +3,7 @@ define gb::public_keys {
   $home         = "/home/${name}"
   $scripts_path = "${home}/scripts/puppet"
   $repo_path    = "${scripts_path}/public-keys"
-  $repo_url     = 'git://github.com/groupbuddies/public-keys.git'
+  $repo_url     = 'git://github.com/subvisual/public-keys.git'
 
   $script_name    = 'generate-authorized_keys.rb'
   $script         = "${scripts_path}/${script_name}"

--- a/puppet-module/metadata.json
+++ b/puppet-module/metadata.json
@@ -3,9 +3,9 @@
   "version": "0.22.0",
   "author": "Miguel Palhas",
   "license": "MIT License",
-  "summary": "Group Buddies base Puppet module",
-  "source": "https://github.com/groupbuddies/gb-puppet/tree/master/puppet-module",
-  "project_page": "https://github.com/groupbuddies/gb-puppet/tree/master/puppet-module",
+  "summary": "Subvisual base Puppet module",
+  "source": "https://github.com/subvisual/subvisual-puppet/tree/master/puppet-module",
+  "project_page": "https://github.com/subvisual/subvisual-puppet/tree/master/puppet-module",
   "operatingsystem_support": [
     { "operatingsystem": "Ubuntu" }
   ],

--- a/setup/ubuntu
+++ b/setup/ubuntu
@@ -5,7 +5,7 @@ set -e
 DISTRO="ubuntu"
 LSB_RELEASE=$(lsb_release --codename --short)
 GB_PUPPET_VERSION="0.23.0"
-MANIFEST="https://raw.githubusercontent.com/groupbuddies/gb-puppet/master/setup/ubuntu.pp"
+MANIFEST="https://raw.githubusercontent.com/subvisual/subvisual-puppet/master/setup/ubuntu.pp"
 OUT=/dev/null
 BASE_PACKAGES="git curl puppet"
 


### PR DESCRIPTION
Why:
- We still had the old name through this repo.

This change addresses the need by:
- Renaming all the gb and Group Buddies references to Subvisual.
